### PR TITLE
Add config option to center window shadow

### DIFF
--- a/breezedecoration.cpp
+++ b/breezedecoration.cpp
@@ -68,6 +68,7 @@ namespace Breeze
     static int g_shadowSizeEnum = InternalSettings::ShadowLarge;
     static int g_shadowStrength = 90;
     static QColor g_shadowColor = Qt::black;
+    static bool g_shadowCentered = false;
     static QSharedPointer<KDecoration2::DecorationShadow> g_sShadow;
 
     //________________________________________________________________
@@ -644,13 +645,15 @@ namespace Breeze
             !g_sShadow  ||
             g_shadowSizeEnum != m_internalSettings->shadowSize() ||
             g_shadowStrength != m_internalSettings->shadowStrength() ||
-            g_shadowColor != m_internalSettings->shadowColor()
+            g_shadowColor != m_internalSettings->shadowColor() ||
+            g_shadowCentered != m_internalSettings->shadowCentered()
             )
         {
             // assign parameters
             g_shadowSizeEnum = m_internalSettings->shadowSize();
             g_shadowStrength = m_internalSettings->shadowStrength();
             g_shadowColor = m_internalSettings->shadowColor();
+            g_shadowCentered = m_internalSettings->shadowCentered();
 
             // shadow size from enum
             int shadowSize = 0;
@@ -666,7 +669,9 @@ namespace Breeze
             }
 
             // offset
-            int shadowOffset = (g_shadowSizeEnum == InternalSettings::ShadowNone) ? 0 : qMax( 6*shadowSize/16, Metrics::Shadow_Overlap*2 );
+            int shadowOffset = 0;
+            if( !m_internalSettings->shadowCentered() )
+                shadowOffset = (g_shadowSizeEnum == InternalSettings::ShadowNone) ? 0 : qMax( 6*shadowSize/16, Metrics::Shadow_Overlap*2 );
 
             // create image
             QImage image(2*shadowSize, 2*shadowSize, QImage::Format_ARGB32_Premultiplied);

--- a/breezesettingsdata.kcfg
+++ b/breezesettingsdata.kcfg
@@ -28,6 +28,10 @@
        <default>35, 38, 41</default>
     </entry>
 
+    <entry name="ShadowCentered" type = "Bool">
+        <default>false</default>
+    </entry>
+
   </group>
 
   <group name="Windeco">

--- a/config/breezeconfigwidget.cpp
+++ b/config/breezeconfigwidget.cpp
@@ -68,6 +68,7 @@ namespace Breeze
         connect( m_ui.shadowSize, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()) );
         connect( m_ui.shadowStrength, SIGNAL(valueChanged(int)), SLOT(updateChanged()) );
         connect( m_ui.shadowColor, SIGNAL(changed(QColor)), SLOT(updateChanged()) );
+        connect( m_ui.shadowCentered, SIGNAL(clicked()), SLOT(updateChanged()) );
 
         // track exception changes
         connect( m_ui.exceptions, SIGNAL(changed(bool)), SLOT(updateChanged()) );
@@ -101,6 +102,7 @@ namespace Breeze
 
         m_ui.shadowStrength->setValue( qRound(qreal(m_internalSettings->shadowStrength()*100)/255 ) );
         m_ui.shadowColor->setColor( m_internalSettings->shadowColor() );
+        m_ui.shadowCentered->setChecked( m_internalSettings->shadowCentered() );
 
         // load exceptions
         ExceptionList exceptions;
@@ -133,6 +135,7 @@ namespace Breeze
         m_internalSettings->setShadowSize( m_ui.shadowSize->currentIndex() );
         m_internalSettings->setShadowStrength( qRound( qreal(m_ui.shadowStrength->value()*255)/100 ) );
         m_internalSettings->setShadowColor( m_ui.shadowColor->color() );
+        m_internalSettings->setShadowCentered( m_ui.shadowCentered->isChecked() );
 
         // save configuration
         m_internalSettings->save();
@@ -181,6 +184,7 @@ namespace Breeze
         m_ui.shadowSize->setCurrentIndex( m_internalSettings->shadowSize() );
         m_ui.shadowStrength->setValue( qRound(qreal(m_internalSettings->shadowStrength()*100)/255 ) );
         m_ui.shadowColor->setColor( m_internalSettings->shadowColor() );
+        m_ui.shadowCentered->setChecked( m_internalSettings->shadowCentered() );
 
     }
 
@@ -211,6 +215,7 @@ namespace Breeze
         else if( m_ui.shadowSize->currentIndex() !=  m_internalSettings->shadowSize() ) modified = true;
         else if( qRound( qreal(m_ui.shadowStrength->value()*255)/100 ) != m_internalSettings->shadowStrength() ) modified = true;
         else if( m_ui.shadowColor->color() != m_internalSettings->shadowColor() ) modified = true;
+        else if( m_ui.shadowCentered->isChecked() != m_internalSettings->shadowCentered() ) modified = true;
 
         // exceptions
         else if( m_ui.exceptions->isChanged() ) modified = true;

--- a/config/ui/breezeconfigurationui.ui
+++ b/config/ui/breezeconfigurationui.ui
@@ -374,7 +374,7 @@
        <item row="2" column="1">
         <widget class="KColorButton" name="shadowColor"/>
        </item>
-       <item row="3" column="0" colspan="3">
+       <item row="4" column="0" colspan="3">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -386,6 +386,20 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="3" column="0" alignment="Qt::AlignRight">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Position:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="shadowCentered">
+         <property name="text">
+          <string>Centered</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
This just adds a simple checkbox to the config that allows users to optionally center the window shadow. Centering the window shadow gives the transparent window decoration a more glass-like aesthetic. Well, imo anyway :)

![screenshot_20181011_222129](https://user-images.githubusercontent.com/3807208/46810785-0199fe00-cda4-11e8-9502-a63ad152286c.png)
